### PR TITLE
[web] Changed nightorder reminder position

### DIFF
--- a/src/components/modals/NightOrderModal.vue
+++ b/src/components/modals/NightOrderModal.vue
@@ -294,7 +294,7 @@ ul {
       }
     }
     .reminder {
-      position: fixed;
+      position: absolute;
       padding: 5px 10px;
       left: 50%;
       bottom: 10%;

--- a/src/components/modals/NightOrderModal.vue
+++ b/src/components/modals/NightOrderModal.vue
@@ -294,11 +294,13 @@ ul {
       }
     }
     .reminder {
-      position: absolute;
+      position: fixed;
       padding: 5px 10px;
       left: 50%;
       bottom: 10%;
-      width: 500px;
+      width: min(500px, 90vw);
+      max-width: 90vw;
+      transform: translateX(20%); // magic number, I don't know why it works
       z-index: 25;
       background: rgba(0, 0, 0, 0.75);
       border-radius: 10px;


### PR DESCRIPTION
Constrained max width to fit it in mobile layout, and moved the reminder box a little to make it (looks like) centered

这个20%纯属magic number，我不太清楚他为什么有效，但是测试下来确实有效( ´д`)